### PR TITLE
Add CRUD functions to `useTaskGroups()` hook

### DIFF
--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -35,6 +35,14 @@ export default function useTaskGroups() {
                 }
             })
         },
+        deleteTaskGroup: (data: TaskGroupPartial) => {
+            dispatchTaskGroups({
+                type: 'delete',
+                data: {
+                    id: data.id
+                }
+            })
+        },
         /**
          * Get task group by id. Throws error if not found.
          * @param {ID} id ID of task group.

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -2,9 +2,8 @@
 import { useContext } from 'react';
 
 //Types
-import TaskGroup from 'types/TaskGroup';
+import TaskGroup, { TaskGroupNoID, TaskGroupOptional } from 'types/TaskGroup';
 import { ID } from 'types/UtilTypes';
-import { TaskGroupNoID } from 'types/TaskGroup';
 
 //State
 import { TaskGroupContext } from 'state/TaskGroupContext';

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -28,6 +28,14 @@ export default function useTaskGroups() {
                 }
             })
         },
+        updateTaskGroup: (data: TaskGroupPartial) => {
+            dispatchTaskGroups({
+                type: 'update',
+                data: {
+                    ...data
+                }
+            })
+        },
         /**
          * Get task group by id. Throws error if not found.
          * @param {ID} id ID of task group.

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -7,6 +7,7 @@ import { ID } from 'types/UtilTypes';
 
 //State
 import { TaskGroupContext } from 'state/TaskGroupContext';
+import { TaskGroupDispatchContext } from 'state/TaskGroupContext';
 
 /**
  * Hook that lets you access and modify task groups.
@@ -15,8 +16,17 @@ export default function useTaskGroups() {
 
     //All task groups
     const taskGroups = useContext(TaskGroupContext)
+    const dispatchTaskGroups = useContext(TaskGroupDispatchContext)
     
     return {
+        createTaskGroup: (data: TaskGroupOptional) => {
+            dispatchTaskGroups({
+                type: 'create',
+                data: {
+                    ...data
+                }
+            })
+        },
         /**
          * Get task group by id. Throws error if not found.
          * @param {ID} id ID of task group.

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -19,6 +19,25 @@ export default function useTaskGroups() {
     const dispatchTaskGroups = useContext(TaskGroupDispatchContext)
     
     return {
+        /**
+         * Get task group by id. Throws error if not found.
+         * @param {ID} id ID of task group.
+         * 
+         * @returns {TaskGroup} Task group with matching id.
+         */
+        getTaskGroupById: (id: ID): TaskGroup => {
+            //Find task group by id from all task groups
+            const task_group = taskGroups.find( group => group.id === id);
+
+            
+            if (task_group) {
+                //If task group found, return it
+                return task_group;
+            } else {
+                //Otherwise throw error
+                throw new Error('Could not find task group by id' + id)
+            }
+        },
         createTaskGroup: (data: TaskGroupNoID) => {
             dispatchTaskGroups({
                 type: 'create',
@@ -49,24 +68,6 @@ export default function useTaskGroups() {
                 data
             })
         },
-        /**
-         * Get task group by id. Throws error if not found.
-         * @param {ID} id ID of task group.
-         * 
-         * @returns {TaskGroup} Task group with matching id.
-         */
-        getTaskGroupById: (id: ID): TaskGroup => {
-            //Find task group by id from all task groups
-            const task_group = taskGroups.find( group => group.id === id);
-
-            
-            if (task_group) {
-                //If task group found, return it
-                return task_group;
-            } else {
-                //Otherwise throw error
-                throw new Error('Could not find task group by id' + id)
-            }
-        }
+        
     }
 }

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -2,7 +2,7 @@
 import { useContext } from 'react';
 
 //Types
-import TaskGroup, { TaskGroupNoID, TaskGroupOptional } from 'types/TaskGroup';
+import TaskGroup, { TaskGroupNoID, TaskGroupPartial } from 'types/TaskGroup';
 import { ID } from 'types/UtilTypes';
 
 //State

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -4,6 +4,7 @@ import { useContext } from 'react';
 //Types
 import TaskGroup from 'types/TaskGroup';
 import { ID } from 'types/UtilTypes';
+import { TaskGroupNoID } from 'types/TaskGroup';
 
 //State
 import { TaskGroupContext } from 'state/TaskGroupContext';
@@ -19,7 +20,7 @@ export default function useTaskGroups() {
     const dispatchTaskGroups = useContext(TaskGroupDispatchContext)
     
     return {
-        createTaskGroup: (data: TaskGroupOptional) => {
+        createTaskGroup: (data: TaskGroupNoID) => {
             dispatchTaskGroups({
                 type: 'create',
                 data: {

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -43,6 +43,12 @@ export default function useTaskGroups() {
                 }
             })
         },
+        setAllTaskGroups: (data: TaskGroup[]) => {
+            dispatchTaskGroups({
+                type: 'set-all',
+                data
+            })
+        },
         /**
          * Get task group by id. Throws error if not found.
          * @param {ID} id ID of task group.

--- a/src/functions/useTaskGroups.ts
+++ b/src/functions/useTaskGroups.ts
@@ -38,6 +38,10 @@ export default function useTaskGroups() {
                 throw new Error('Could not find task group by id' + id)
             }
         },
+        /**
+         * Create new task group from data
+         * @param { TaskGroupNoID } data Task group to create 
+         */
         createTaskGroup: (data: TaskGroupNoID) => {
             dispatchTaskGroups({
                 type: 'create',
@@ -46,6 +50,10 @@ export default function useTaskGroups() {
                 }
             })
         },
+        /**
+         * Update task group from data
+         * @param { TaskGroupPartial } data Task group to update. Only `id` required
+         */
         updateTaskGroup: (data: TaskGroupPartial) => {
             dispatchTaskGroups({
                 type: 'update',
@@ -54,6 +62,10 @@ export default function useTaskGroups() {
                 }
             })
         },
+        /**
+         * Delete task group
+         * @param { TaskGroupPartial } data Task group to delete. Only `id` required
+         */
         deleteTaskGroup: (data: TaskGroupPartial) => {
             dispatchTaskGroups({
                 type: 'delete',
@@ -62,6 +74,10 @@ export default function useTaskGroups() {
                 }
             })
         },
+        /**
+         * Set state of all task groups to the provided array of task groups
+         * @param { TaskGroup[] } data Task groups to set the state to
+         */
         setAllTaskGroups: (data: TaskGroup[]) => {
             dispatchTaskGroups({
                 type: 'set-all',

--- a/src/pages/TaskGroupEditPage.tsx
+++ b/src/pages/TaskGroupEditPage.tsx
@@ -93,7 +93,12 @@ export default function TaskGroupEditPage() {
     //Hooks
     const { state }: { state: RouteState } = useLocation();
     const navigate = useNavigate();
-    const { getTaskGroupById } = useTaskGroups();
+    const { 
+        getTaskGroupById,
+        createTaskGroup,
+        updateTaskGroup,
+        deleteTaskGroup
+    } = useTaskGroups();
 
     const task_group = useMemo(() => {
         if (state?.id != null && state?.id !== undefined) {
@@ -101,9 +106,6 @@ export default function TaskGroupEditPage() {
         }
         return null
     }, [state?.id])
-    
-    //#TODO: Change dispatch to useTaskGroups()
-    const dispatchTaskGroups: TaskGroupDispatch = useContext(TaskGroupDispatchContext)
 
     //Handle submit of form
     const handleSubmit = (values: FormValues) => {
@@ -119,21 +121,13 @@ export default function TaskGroupEditPage() {
 
         //If ID param passed, update task group
         if (state && state.id) {
-            dispatchTaskGroups({
-                type: 'update',
-                data: {
-                    id: state.id,
-                    ...data
-                }
+            updateTaskGroup({
+                id: state.id,
+                ...data
             })
         } else { //Otherwise create a new one
             console.log('creating new group')
-            dispatchTaskGroups({
-                type: 'create',
-                data: {
-                    ...data
-                }
-            })
+            createTaskGroup(data)
         }
         //Finally, navigate back to the Schedule page
         navigate('/');
@@ -142,11 +136,8 @@ export default function TaskGroupEditPage() {
     //Handle 'delete' button click
     const handleDeleteButtonClick = () => {
         //#TODO: Consider adding an ID check to make sure that task group exists
-        dispatchTaskGroups({
-            type: 'delete',
-            data: {
-                id: state.id!
-            }
+        deleteTaskGroup({
+            id: state.id!
         })
         //After deleting task group, navigate back to the Schedule page
         navigate('/')

--- a/src/types/TaskGroup.ts
+++ b/src/types/TaskGroup.ts
@@ -11,13 +11,13 @@ type TaskGroup = {
     color: string //Color of the task group as displayed in task group lists
 }
 
-type TaskGroupOptional = Omit<Partial<TaskGroup>, 'id'> & {id: ID}
+type TaskGroupPartial = Omit<Partial<TaskGroup>, 'id'> & {id: ID}
 
 type TaskGroupNoID = Omit<TaskGroup, 'id'>
 
 export { 
     type TaskGroupNoID, 
-    type TaskGroupOptional 
+    type TaskGroupPartial
 }
 
 export default TaskGroup

--- a/src/types/TaskGroup.ts
+++ b/src/types/TaskGroup.ts
@@ -11,4 +11,13 @@ type TaskGroup = {
     color: string //Color of the task group as displayed in task group lists
 }
 
+type TaskGroupOptional = Omit<Partial<TaskGroup>, 'id'> & {id: ID}
+
+type TaskGroupNoID = Omit<TaskGroup, 'id'>
+
+export { 
+    type TaskGroupNoID, 
+    type TaskGroupOptional 
+}
+
 export default TaskGroup


### PR DESCRIPTION
This PR introduces CRUD functionality to the `useTaskGroups()` hook and changes the usage of task group dispatch to usage of these newly implemented functions