### PR TITLE
dai-31 - Fix input size not adjusting to font size setting

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -577,7 +577,20 @@ select {
   background-size: 24px;
   background-position: calc(100% - 6px) center;
   box-sizing: border-box;
-  width: fit-content
+  width: fit-content;
+  font-size: 0.9rem;
+}
+
+input { 
+  font-size: 0.9rem;
+}
+
+textarea {
+  font-size: 0.9rem;
+}
+
+button {
+  font-size: 0.9rem;
 }
 
 /* Typography */


### PR DESCRIPTION
This PR fixes the bug where `input`/`select`/`textarea` font sizes didn't change according to the font size setting